### PR TITLE
update with version numbers (so terraform won't complain about newer modules

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -1,8 +1,9 @@
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
   cluster_name    = local.cluster_name
-  cluster_version = "1.18"
+  cluster_version = "1.21"
   subnets         = module.vpc.private_subnets
+  version         = "11.0.0"
 
   tags = {
     Environment = "training"

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -3,4 +3,5 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   token                  = data.aws_eks_cluster_auth.cluster.token
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  version                = "1.11.4"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 provider "random" {


### PR DESCRIPTION
Hi, consider updating with exact versions of modules/providers defined, so TF (set to now-old ~>0.13.0 for compatibility) won't complain about the latest versions which get downloaded automatically.